### PR TITLE
DBの設計

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,10 @@
-# README
+## groups_usersテーブル
 
-This README would normally document whatever steps are necessary to get the
-application up and running.
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
 
-Things you may want to cover:
-
-* Ruby version
-
-* System dependencies
-
-* Configuration
-
-* Database creation
-
-* Database initialization
-
-* How to run the test suite
-
-* Services (job queues, cache servers, search engines, etc.)
-
-* Deployment instructions
-
-* ...
+### Association
+- belongs_to :group
+- belongs_to :user

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@
 
 |Column|Type|Options|
 |------|----|-------|
-|message|text|null: false|
-|photo|text|null: true|
+|body|text|
+|photo|text|
 |user_id|integer|null: false, foreign_key: true|
 |group_id|integer|null: false, foreign_key: true|
 

--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@
 |name|string|null: false|
 |email|string|null: false|
 |password|string|null: false|
-|group_id|integer|null: false, foreign_key: true|
 
 ### Association
+- has_many :groups_users
 - has_many :groups, through: :groups_users
 - has_many :messages
 
@@ -16,11 +16,12 @@
 
 |Column|Type|Options|
 |------|----|-------|
-|group|string|null: false|
-|user_id|integer|null: false, foreign_key: true|
+|name|string|null: false|
 
 ### Association
+- has_many :groups_users
 - has_many :users, through: :groups_users
+- has_many :messages
 
 
 ## messagesテーブル
@@ -28,6 +29,7 @@
 |Column|Type|Options|
 |------|----|-------|
 |message|text|null: false|
+|photo|text|null: true|
 |user_id|integer|null: false, foreign_key: true|
 |group_id|integer|null: false, foreign_key: true|
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,41 @@
+## usersテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|name|string|null: false|
+|email|string|null: false|
+|password|string|null: false|
+|group_id|integer|null: false, foreign_key: true|
+
+### Association
+- has_many :groups, through: :groups_users
+- has_many :messages
+
+
+## groupsテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|group|string|null: false|
+|user_id|integer|null: false, foreign_key: true|
+
+### Association
+- has_many :users, through: :groups_users
+
+
+## messagesテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|message|text|null: false|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+
+### Association
+- belongs_to :user
+- belongs_to :group
+
+
 ## groups_usersテーブル
 
 |Column|Type|Options|


### PR DESCRIPTION
#WHAT
●chat-spaceのデータベースを作成する
●ユーザー情報の登録：usersテーブル
●グループ情報の登録：groupsテーブル
●メッセージ情報の登録：messagesテーブル
●グループ内のメンバー情報の登録：groups_usersテーブル（中間テーブル）

#WHY
メンバー情報＝ユーザー情報であると考えたため、
usersテーブルとgroupsテーブルは多対多の関係になる。
そのため、中間テーブルとしてgroups_usersテーブルを用意した。

